### PR TITLE
Ollama and Groq Models Through Native Python SDKs

### DIFF
--- a/prompt_library.py
+++ b/prompt_library.py
@@ -22,24 +22,29 @@ def __(prompt_library_module):
 def __(llm_module):
     llm_o1_mini, llm_o1_preview = llm_module.build_o1_series()
     llm_gpt_4o_latest, llm_gpt_4o_mini = llm_module.build_openai_latest_and_fastest()
-    # llm_sonnet = llm_module.build_sonnet_3_5()
-    # gemini_1_5_pro, gemini_1_5_flash = llm_module.build_gemini_duo()
+    mistral_model, phi4_14b_model, llama3_2_model = llm_module.build_ollama_models()
+    llama_3_3_70b_versatile_model = llm_module.build_groq_models()
 
     models = {
         "o1-mini": llm_o1_mini,
         "o1-preview": llm_o1_preview,
         "gpt-4o-latest": llm_gpt_4o_latest,
         "gpt-4o-mini": llm_gpt_4o_mini,
-        # "sonnet-3.5": llm_sonnet,
-        # "gemini-1-5-pro": gemini_1_5_pro,
-        # "gemini-1-5-flash": gemini_1_5_flash,
+        "phi4": phi4_14b_model,
+        "mistral": mistral_model,
+        "llama3.2": llama3_2_model,
+        "groq:llama-3.3-70b-versatile": llama_3_3_70b_versatile_model,
     }
     return (
+        llama3_2_model,
+        llama_3_3_70b_versatile_model,
         llm_gpt_4o_latest,
         llm_gpt_4o_mini,
         llm_o1_mini,
         llm_o1_preview,
+        mistral_model,
         models,
+        phi4_14b_model,
     )
 
 
@@ -197,6 +202,11 @@ def __(context_filled_prompt, form, llm_module, mo):
         {"background": "#eee", "padding": "10px", "border-radius": "10px"}
     )
     return model, prompt_response
+
+
+@app.cell
+def __():
+    return
 
 
 if __name__ == "__main__":

--- a/scrape.py
+++ b/scrape.py
@@ -1,0 +1,40 @@
+import marimo
+
+__generated_with = "0.8.18"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import asyncio
+    from crawl4ai import AsyncWebCrawler
+    return AsyncWebCrawler, asyncio, mo
+
+
+@app.cell
+def __(AsyncWebCrawler):
+    async def main():
+        async with AsyncWebCrawler() as crawler:
+            result = await crawler.arun(
+                url="https://www.anthropic.com/research/alignment-faking",
+            )
+            print(result.markdown)
+            
+    return (main,)
+
+
+@app.cell
+async def __(main, mo):
+    with mo.status.spinner(title="Running prompt..."):
+        await main()
+    return
+
+
+@app.cell
+def __():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/marimo_notebook/modules/groq.py
+++ b/src/marimo_notebook/modules/groq.py
@@ -1,3 +1,4 @@
+from __future__ import annotations  # For forward references in type hints
 from typing import Iterator, Optional, Dict, Type, List
 from llm import Model, Prompt, Response, Conversation
 from groq import Groq
@@ -7,21 +8,38 @@ import os
 load_dotenv()
 
 class GroqModel(Model):
+    """
+    A model class for interacting with the Groq API using specified models.
+    """
+
     model_id: str
     needs_key: str = "Groq API key"
     key_env_var: str = "GROQ_API_KEY"
     can_stream: bool = True
 
     def __init__(self, model_id: str = "mixtral-8x7b-32768", **kwargs):
+        """
+        Initialize the GroqModel.
+
+        Args:
+            model_id: The ID of the Groq model to use.
+            **kwargs: Additional keyword arguments.
+        """
         self.model_id = model_id
         self.client = None
         super().__init__(**kwargs)
 
     def _ensure_client(self):
+        """
+        Ensure the Groq client is initialized.
+        """
         if self.client is None:
             if not self.key:
                 raise ValueError("Groq API key is required")
-            self.client = Groq(api_key=self.key)
+            try:
+                self.client = Groq(api_key=self.key)
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize Groq client: {e}")
 
     def execute(
         self,
@@ -30,6 +48,18 @@ class GroqModel(Model):
         response: Response,
         conversation: Optional[Conversation],
     ) -> Iterator[str]:
+        """
+        Execute a prompt using the Groq model.
+
+        Args:
+            prompt: The Prompt object containing the prompt text.
+            stream: Whether to stream the response.
+            response: The Response object to populate.
+            conversation: The Conversation context, if any.
+
+        Yields:
+            Generated text from the model.
+        """
         self._ensure_client()
 
         messages = []
@@ -45,13 +75,16 @@ class GroqModel(Model):
         # Add the current prompt
         messages.append({"role": "user", "content": prompt.prompt})
 
-        completion = self.client.chat.completions.create(
-            model=self.model_id,
-            messages=messages,
-            stream=stream,
-            temperature=prompt.options.get("temperature", 0.7),
-            max_tokens=prompt.options.get("max_tokens", None),
-        )
+        try:
+            completion = self.client.chat.completions.create(
+                model=self.model_id,
+                messages=messages,
+                stream=stream,
+                temperature= getattr(prompt.options, "temperature", 0.7),
+                max_tokens= getattr(prompt.options, "max_tokens", None),
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate completion: {e}")
 
         if stream:
             for chunk in completion:
@@ -61,25 +94,55 @@ class GroqModel(Model):
             yield completion.choices[0].message.content
 
         # Store usage information if available
-        if hasattr(completion, "usage"):
-            response.prompt_tokens = completion.usage.prompt_tokens
-            response.completion_tokens = completion.usage.completion_tokens
+        usage = getattr(completion, "usage", None)
+        if usage:
+            response.prompt_tokens = usage.prompt_tokens
+            response.completion_tokens = usage.completion_tokens
+
+    def close(self):
+        """
+        Close the Groq client and release any resources.
+        """
+        if self.client:
+            self.client.close()
+            self.client = None
+
+    def __enter__(self):
+        self._ensure_client()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    @classmethod
+    def get_supported_models(cls) -> List[str]:
+        """
+        Retrieve a list of supported Groq model IDs.
+
+        Returns:
+            A list of model IDs supported by the Groq API.
+        """
+        key = os.getenv(cls.key_env_var)
+        if not key:
+            raise ValueError("Groq API key is required to retrieve supported models")
+        try:
+            client = Groq(api_key=key)
+            models = [model.id for model in client.models.list().data]
+            client.close()
+            return models
+        except Exception as e:
+            raise RuntimeError(f"Failed to retrieve supported models: {e}")
 
 class Options(Model.Options):
+    """
+    Options for configuring the Groq model behavior.
+    """
     temperature: Optional[float] = 0.7
     max_tokens: Optional[int] = None
     top_p: Optional[float] = 1.0
     # Add other Groq-specific parameters as needed
 
-client = Groq(api_key=os.getenv("GROQ_API_KEY"))
-SUPPORTED_MODELS = [
-    model.id for model in client.models.list().data
-]
-client = None;
-
-_models: Dict[str, Type[GroqModel]] = {}
-
-def get_model(model_name: str) -> "GroqModel":
+def get_model(model_name: str) -> GroqModel:
     """
     Get a Groq model instance by name.
     
@@ -92,10 +155,11 @@ def get_model(model_name: str) -> "GroqModel":
     Raises:
         ValueError: If the model name is not recognized
     """
-    if model_name not in SUPPORTED_MODELS:
+    supported_models = GroqModel.get_supported_models()
+    if model_name not in supported_models:
         raise ValueError(
             f"Unknown model: {model_name}. "
-            f"Supported models are: {', '.join(SUPPORTED_MODELS)}"
+            f"Supported models are: {', '.join(supported_models)}"
         )
     return GroqModel(model_id=model_name)
 

--- a/src/marimo_notebook/modules/groq.py
+++ b/src/marimo_notebook/modules/groq.py
@@ -1,6 +1,10 @@
 from typing import Iterator, Optional, Dict, Type, List
 from llm import Model, Prompt, Response, Conversation
 from groq import Groq
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
 
 class GroqModel(Model):
     model_id: str
@@ -67,13 +71,11 @@ class Options(Model.Options):
     top_p: Optional[float] = 1.0
     # Add other Groq-specific parameters as needed
 
-
+client = Groq(api_key=os.getenv("GROQ_API_KEY"))
 SUPPORTED_MODELS = [
-    "mixtral-8x7b-32768",
-    "llama-3.3-70b-versatile",
-    "gemma2-9b-it",
-    "llama-3.1-8b-instant",
+    model.id for model in client.models.list().data
 ]
+client = None;
 
 _models: Dict[str, Type[GroqModel]] = {}
 

--- a/src/marimo_notebook/modules/groq.py
+++ b/src/marimo_notebook/modules/groq.py
@@ -1,0 +1,101 @@
+from typing import Iterator, Optional, Dict, Type, List
+from llm import Model, Prompt, Response, Conversation
+from groq import Groq
+
+class GroqModel(Model):
+    model_id: str
+    needs_key: str = "Groq API key"
+    key_env_var: str = "GROQ_API_KEY"
+    can_stream: bool = True
+
+    def __init__(self, model_id: str = "mixtral-8x7b-32768", **kwargs):
+        self.model_id = model_id
+        self.client = None
+        super().__init__(**kwargs)
+
+    def _ensure_client(self):
+        if self.client is None:
+            if not self.key:
+                raise ValueError("Groq API key is required")
+            self.client = Groq(api_key=self.key)
+
+    def execute(
+        self,
+        prompt: Prompt,
+        stream: bool,
+        response: Response,
+        conversation: Optional[Conversation],
+    ) -> Iterator[str]:
+        self._ensure_client()
+
+        messages = []
+        if prompt.system:
+            messages.append({"role": "system", "content": prompt.system})
+        
+        # Handle conversation history if present
+        if conversation and conversation.messages:
+            for msg in conversation.messages:
+                role = "assistant" if msg.type == "response" else "user"
+                messages.append({"role": role, "content": msg.prompt.prompt})
+
+        # Add the current prompt
+        messages.append({"role": "user", "content": prompt.prompt})
+
+        completion = self.client.chat.completions.create(
+            model=self.model_id,
+            messages=messages,
+            stream=stream,
+            temperature=prompt.options.get("temperature", 0.7),
+            max_tokens=prompt.options.get("max_tokens", None),
+        )
+
+        if stream:
+            for chunk in completion:
+                if chunk.choices[0].delta.content:
+                    yield chunk.choices[0].delta.content
+        else:
+            yield completion.choices[0].message.content
+
+        # Store usage information if available
+        if hasattr(completion, "usage"):
+            response.prompt_tokens = completion.usage.prompt_tokens
+            response.completion_tokens = completion.usage.completion_tokens
+
+class Options(Model.Options):
+    temperature: Optional[float] = 0.7
+    max_tokens: Optional[int] = None
+    top_p: Optional[float] = 1.0
+    # Add other Groq-specific parameters as needed
+
+
+SUPPORTED_MODELS = [
+    "mixtral-8x7b-32768",
+    "llama-3.3-70b-versatile",
+    "gemma2-9b-it",
+    "llama-3.1-8b-instant",
+]
+
+_models: Dict[str, Type[GroqModel]] = {}
+
+def get_model(model_name: str) -> "GroqModel":
+    """
+    Get a Groq model instance by name.
+    
+    Args:
+        model_name: Name of the Groq model to use (e.g., "mixtral-8x7b-32768", "llama2-70b-4096")
+    
+    Returns:
+        GroqModel: An instance of GroqModel configured for the specified model
+    
+    Raises:
+        ValueError: If the model name is not recognized
+    """
+    if model_name not in SUPPORTED_MODELS:
+        raise ValueError(
+            f"Unknown model: {model_name}. "
+            f"Supported models are: {', '.join(SUPPORTED_MODELS)}"
+        )
+    return GroqModel(model_id=model_name)
+
+
+

--- a/src/marimo_notebook/modules/ollama.py
+++ b/src/marimo_notebook/modules/ollama.py
@@ -1,0 +1,87 @@
+from typing import Iterator, Optional, Dict, Type, List
+from llm import Model, Prompt, Response, Conversation
+import ollama
+
+class OllamaModel(Model):
+    model_id: str
+    needs_key: str = None  # Ollama doesn't need an API key
+    key_env_var: str = None
+    can_stream: bool = True
+
+    def __init__(self, model_id: str = "mistral", **kwargs):
+        self.model_id = model_id
+        super().__init__(**kwargs)
+
+    def execute(
+        self,
+        prompt: Prompt,
+        stream: bool,
+        response: Response,
+        conversation: Optional[Conversation],
+    ) -> Iterator[str]:
+        messages = []
+        if prompt.system:
+            messages.append({"role": "system", "content": prompt.system})
+        
+        # Handle conversation history if present
+        if conversation and conversation.messages:
+            for msg in conversation.messages:
+                role = "assistant" if msg.type == "response" else "user"
+                messages.append({"role": role, "content": msg.prompt.prompt})
+
+        # Add the current prompt
+        messages.append({"role": "user", "content": prompt.prompt})
+
+        # Access options directly instead of using .get()
+        options = {
+            "temperature": getattr(prompt.options, "temperature", 0.7),
+            "num_predict": getattr(prompt.options, "max_tokens", None),
+            "top_p": getattr(prompt.options, "top_p", 1.0),
+        }
+
+        completion = ollama.chat(
+            model=self.model_id,
+            messages=messages,
+            stream=stream,
+            options=options,
+        )
+
+        if stream:
+            for chunk in completion:
+                if chunk.get("message", {}).get("content"):
+                    yield chunk["message"]["content"]
+        else:
+            yield completion["message"]["content"]
+
+class Options(Model.Options):
+    temperature: Optional[float] = 0.7
+    max_tokens: Optional[int] = None
+    top_p: Optional[float] = 1.0
+    # Add other Ollama-specific parameters as needed
+
+SUPPORTED_MODELS = [model['name'] for model in ollama.list().get('models', [])]
+
+_models: Dict[str, Type[OllamaModel]] = {}
+
+def get_model(model_name: str) -> "OllamaModel":
+    """
+    Get an Ollama model instance by name.
+    
+    Args:
+        model_name: Name of the Ollama model to use (e.g., "mistral", "llama2")
+    
+    Returns:
+        OllamaModel: An instance of OllamaModel configured for the specified model
+    
+    Raises:
+        ValueError: If the model name is not recognized
+    """
+    if model_name not in SUPPORTED_MODELS:
+        raise ValueError(
+            f"Unknown model: {model_name}. "
+            f"Supported models are: {', '.join(SUPPORTED_MODELS)}"
+        )
+    return OllamaModel(model_id=model_name)
+
+
+

--- a/src/marimo_notebook/modules/ollama.py
+++ b/src/marimo_notebook/modules/ollama.py
@@ -1,14 +1,25 @@
-from typing import Iterator, Optional, Dict, Type, List
+from __future__ import annotations
+from typing import Iterator, Optional, List
 from llm import Model, Prompt, Response, Conversation
 import ollama
 
 class OllamaModel(Model):
+    """
+    A model class for interacting with the Ollama API.
+    """
     model_id: str
     needs_key: str = None  # Ollama doesn't need an API key
     key_env_var: str = None
     can_stream: bool = True
 
     def __init__(self, model_id: str = "mistral", **kwargs):
+        """
+        Initialize the OllamaModel.
+
+        Args:
+            model_id: The ID of the Ollama model to use.
+            **kwargs: Additional keyword arguments.
+        """
         self.model_id = model_id
         super().__init__(**kwargs)
 
@@ -19,6 +30,18 @@ class OllamaModel(Model):
         response: Response,
         conversation: Optional[Conversation],
     ) -> Iterator[str]:
+        """
+        Execute a prompt using the Ollama model.
+
+        Args:
+            prompt: The Prompt object containing the prompt text.
+            stream: Whether to stream the response.
+            response: The Response object to populate.
+            conversation: The Conversation context, if any.
+
+        Yields:
+            Generated text from the model.
+        """
         messages = []
         if prompt.system:
             messages.append({"role": "system", "content": prompt.system})
@@ -39,12 +62,15 @@ class OllamaModel(Model):
             "top_p": getattr(prompt.options, "top_p", 1.0),
         }
 
-        completion = ollama.chat(
-            model=self.model_id,
-            messages=messages,
-            stream=stream,
-            options=options,
-        )
+        try:
+            completion = ollama.chat(
+                model=self.model_id,
+                messages=messages,
+                stream=stream,
+                options=options,
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate completion for model '{self.model_id}': {e}")
 
         if stream:
             for chunk in completion:
@@ -53,17 +79,30 @@ class OllamaModel(Model):
         else:
             yield completion["message"]["content"]
 
+    @classmethod
+    def get_supported_models(cls) -> List[str]:
+        """
+        Retrieve a list of supported Ollama model names.
+
+        Returns:
+            A list of model names supported by the Ollama API.
+        """
+        try:
+            models_data = ollama.list().get('models', [])
+            return [model['name'] for model in models_data]
+        except Exception as e:
+            raise RuntimeError(f"Failed to retrieve supported models: {e}")
+
 class Options(Model.Options):
+    """
+    Options for configuring the Ollama model behavior.
+    """
     temperature: Optional[float] = 0.7
     max_tokens: Optional[int] = None
     top_p: Optional[float] = 1.0
     # Add other Ollama-specific parameters as needed
 
-SUPPORTED_MODELS = [model['name'] for model in ollama.list().get('models', [])]
-
-_models: Dict[str, Type[OllamaModel]] = {}
-
-def get_model(model_name: str) -> "OllamaModel":
+def get_model(model_name: str) -> OllamaModel:
     """
     Get an Ollama model instance by name.
     
@@ -76,10 +115,11 @@ def get_model(model_name: str) -> "OllamaModel":
     Raises:
         ValueError: If the model name is not recognized
     """
-    if model_name not in SUPPORTED_MODELS:
+    supported_models = OllamaModel.get_supported_models()
+    if model_name not in supported_models:
         raise ValueError(
             f"Unknown model: {model_name}. "
-            f"Supported models are: {', '.join(SUPPORTED_MODELS)}"
+            f"Supported models are: {', '.join(supported_models)}"
         )
     return OllamaModel(model_id=model_name)
 


### PR DESCRIPTION
Problem:
I wanted to be able to chose between Ollama and OpenAI without config changes. Without installing plugins the `llm` methods were limiting to either OpenAI or OpenAI compatible services. 

Solution:
To add more seamless support for Ollama and Groq(cloud) I added bridges that interface directly with the Python SDKs for the services.